### PR TITLE
Update lowercase-keys to v2 and drop support for node<8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
-  - '6'
-  - '4'
 script: npm test
 after_success: npm run coverage
 notifications:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "xo": "^0.19.0"
   },
   "dependencies": {
-    "lowercase-keys": "^1.0.0"
+    "lowercase-keys": "^2.0.0"
   }
 }


### PR DESCRIPTION
To completely dedupe it in `cacheable-request`.  It'll require a major version bump here, though, to drop `node<8`.